### PR TITLE
Update index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -73,7 +73,7 @@ export interface TimelinesChartGenericInstance<ChainableInstance> {
   zScaleLabel(): string;
   zScaleLabel(text: string): ChainableInstance;
 
-  sort(cmpFn: CompareFn<string>): ChainableInstance;
+  sort(labelcmpFn: CompareFn<string>,grpcmpFn: CompareFn<string>): ChainableInstance;
   sortAlpha(ascending: boolean): ChainableInstance;
   sortChrono(ascending: boolean): ChainableInstance;
   zoomX(): Range<TS | null> | null;


### PR DESCRIPTION
the .ts file sort function declaration doesnt match with that of the function definition of 2 parameters
and this is a simple bug where always the group comparision is taken as null when we call it as only 1 paramater is mentioned in the typescript function declaration

Do merge this simple PR