### PR TITLE
Fixed for Node 22 'assert' compile error

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import babel from '@rollup/plugin-babel';
 import terser from "@rollup/plugin-terser";
 import dts from 'rollup-plugin-dts';
 
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 const { name, homepage, version, dependencies, peerDependencies } = pkg;
 
 const umdConf = {


### PR DESCRIPTION
There was a compile error under Node 22 LTS. Apparently this is because "import assertionss' has been removed in favour of 'import attributes'. There's a Statck Overflow forum post suggesting this change.